### PR TITLE
Update import statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pip install hi-dateinfer
 -------------------------
 
 ````Python
->>> import dateinfer
+>>> import hidateinfer as dateinfer
 >>> dateinfer.infer(['Mon Jan 13 09:52:52 MST 2014', 'Tue Jan 21 15:30:00 EST 2014'])
 '%a %b %d %H:%M:%S %Z %Y'
 >>>


### PR DESCRIPTION
## Motivation

New users to python may not know to rename the import when using the library, and run into an error where the "dateinfer" library is not detected.